### PR TITLE
Rename last event to last motion event

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Fetch the latest snapshot for a camera and optionally save it locally.
 If `filename` is omitted, the integration automatically uses:
 
 ```text
-<camera_id>_latest.jpg
+<camera_id>_latest_motion.jpg
 ```
 
 Example:
@@ -238,13 +238,13 @@ target:
 Saved file:
 
 ```text
-/config/www/blueiris/driveway_latest.jpg
+/config/www/blueiris/driveway_latest_motion.jpg
 ```
 
 Accessible in Home Assistant as:
 
 ```text
-/local/blueiris/driveway_latest.jpg
+/local/blueiris/driveway_latest_motion.jpg
 ```
 
 ## Trigger Camera
@@ -341,7 +341,7 @@ action:
       title: "Blue Iris: Driveway"
       message: "{{ states('sensor.driveway_last_motion_event') }}"
       data:
-        image: "/local/blueiris/driveway_latest.jpg?v={{ now().timestamp() }}"
+        image: "/local/blueiris/driveway_latest_motion.jpg?v={{ now().timestamp() }}"
 ```
 
 ### Cache Busting

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Home Assistant integration for **Blue Iris Video Security Software**.
 
 This is/was designed (original design by elad-bar), reviewed, and tested by me. AI assisted in generating documentation and some logic/design patterns.
 
-This integration allows Home Assistant to interact with your Blue Iris server, providing cameras, sensors, profile control, AI event tracking, snapshot support, and automation-friendly entities.
+This integration allows Home Assistant to interact with your Blue Iris server, providing cameras, sensors, profile control, motion event tracking, snapshot support, and automation-friendly entities.
 
 📄 **Changelog**  
 [CHANGELOG.md](https://github.com/kramttocs/ha-blueiris/blob/main/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ This integration allows Home Assistant to interact with your Blue Iris server, p
 - [AI Label Mapping](#ai-label-mapping)
 - [Entities and Components](#entities-and-components)
   - [Binary Sensors](#binary-sensors)
-  - [Last Event Sensors](#last-event-sensors)
+  - [Last Motion Event Sensors](#last-motion-event-sensors)
   - [Update Sensors](#update-sensors)
   - [Camera Entity](#camera-entity)
   - [Profile Switches](#profile-switches)
 - [Services](#services)
-  - [Latest Event Snapshot](#latest-event-snapshot)
+  - [Latest Motion Event Snapshot](#latest-motion-event-snapshot)
   - [Trigger Camera](#trigger-camera)
   - [Move to Preset](#move-to-preset)
   - [Reload](#reload)
 - [Blueprint](#blueprint)
-  - [Blue Iris - Last Event Notifications](#blue-iris---last-event-notifications)
+  - [Blue Iris - Last Motion Event Notifications](#blue-iris---last-motion-event-notifications)
 - [Example Automation](#example-automation)
 
 ---
@@ -145,14 +145,14 @@ Server sensors:
 
 - Alerts
 
-## Last Event Sensors
+## Last Motion Event Sensors
 
-Each camera configured with **Motion Sensors** also provides a **Last Event sensor**.
+Each camera configured with **Motion Sensors** also provides a **Last Motion Event sensor**.
 
 Example entity:
 
 ```text
-sensor.driveway_last_event
+sensor.driveway_last_motion_event
 ```
 
 Example state:
@@ -175,11 +175,11 @@ Example attributes:
 
 When a new event occurs, the stored snapshot path is cleared until a new snapshot is saved.
 
-### Why Last Event Sensors Matter
+### Why Last Motion Event Sensors Matter
 
 These sensors are designed to be automation-friendly and work especially well for notifications, camera-specific logic, and alarm-aware workflows.
 
-If you want a ready-to-use notification setup based on these sensors, see the blueprint below.
+If you want a ready-to-use notification setup based on these sensors, see the motion-focused blueprint below.
 
 ## Update Sensors
 
@@ -212,7 +212,7 @@ Behavior when turning a profile **off**:
 
 # Services
 
-## Latest Event Snapshot
+## Latest Motion Event Snapshot
 
 Fetch the latest snapshot for a camera and optionally save it locally.
 
@@ -230,7 +230,7 @@ If `filename` is omitted, the integration automatically uses:
 Example:
 
 ```yaml
-service: blueiris.latest_event_snapshot
+service: blueiris.latest_motion_event_snapshot
 target:
   entity_id: camera.driveway
 ```
@@ -263,31 +263,33 @@ Reloads the integration without restarting Home Assistant.
 
 # Blueprint
 
-## Blue Iris - Last Event Notifications
+## Blue Iris - Last Motion Event Notifications
 
-I strongly suggest checking out this blueprint if you want to see one way the last even sensor can be used.
+I strongly suggest checking out this blueprint if you want to see one way the last motion event sensor can be used.
 
 The blueprint uses the integration’s:
 
-- **Last Event sensors**
+- **Last Motion Event sensors**
 - **camera entities**
-- **latest event snapshot service**
+- **latest motion event snapshot service**
 
-to create alarm-aware and camera-specific notifications with optional mute support.
+to create alarm-aware and camera-specific motion notifications with optional mute support.
 
 ### What the Blueprint Adds
 
-- Notifications from multiple Blue Iris `*_last_event` sensors using one automation
-- Filtering by `event_type` such as:
+- Notifications from multiple Blue Iris `*_last_motion_event` sensors using one automation
+- Filtering by motion `event_type` values such as:
   - `motion_person`
   - `motion_vehicle`
   - `motion_animal`
+  - `motion_multi`
+  - `motion`
 - Camera-specific suppression by alarm state:
   - `armed_home`
   - `armed_away`
   - `armed_night`
   - `armed_vacation`
-- Snapshot image support using the integration’s saved latest-event image
+- Snapshot image support using the integration’s saved latest motion-event image
 - Optional dynamic dashboard navigation per camera
 - Optional mute action support using a helper and companion automations
 
@@ -305,7 +307,7 @@ For full setup instructions, inputs, examples, and optional companion mute autom
 ### Notes
 
 - The blueprint assumes the following naming relationship:
-  - `sensor.<camera_object_id>_last_event`
+  - `sensor.<camera_object_id>_last_motion_event`
   - `camera.<camera_object_id>`
 - The blueprint supports notifications with or without a locally saved snapshot image.
 - If you use the optional mute action, follow the companion automation setup in the blueprint documentation.
@@ -322,7 +324,7 @@ mode: queued
 
 trigger:
   - platform: state
-    entity_id: sensor.driveway_last_event
+    entity_id: sensor.driveway_last_motion_event
 
 condition:
   - condition: template
@@ -330,14 +332,14 @@ condition:
       {{ trigger.to_state.state not in ['unknown','unavailable','none','idle','No event'] }}
 
 action:
-  - service: blueiris.latest_event_snapshot
+  - service: blueiris.latest_motion_event_snapshot
     target:
       entity_id: camera.driveway
 
   - service: notify.mobile_app_your_phone
     data:
       title: "Blue Iris: Driveway"
-      message: "{{ states('sensor.driveway_last_event') }}"
+      message: "{{ states('sensor.driveway_last_motion_event') }}"
       data:
         image: "/local/blueiris/driveway_latest.jpg?v={{ now().timestamp() }}"
 ```

--- a/custom_components/blueiris/__init__.py
+++ b/custom_components/blueiris/__init__.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any
-from functools import partial
 
 import voluptuous as vol
 
@@ -31,7 +30,7 @@ from .helpers.const import (
     SERVICE_TRIGGER_CAMERA,
     SERVICE_RELOAD,
     SERVICE_RELOAD_ENTRY_ID,
-    SERVICE_LATEST_EVENT_SNAPSHOT,
+    SERVICE_LATEST_MOTION_EVENT_SNAPSHOT,
     SERVICE_SNAPSHOT_FILENAME,
 )
 
@@ -46,7 +45,7 @@ PRESET_SCHEMA = vol.Schema(
     }
 )
 RELOAD_SCHEMA = vol.Schema({vol.Optional(SERVICE_RELOAD_ENTRY_ID): cv.string})
-LATEST_EVENT_SNAPSHOT_SCHEMA = vol.Schema(
+LATEST_MOTION_EVENT_SNAPSHOT_SCHEMA = vol.Schema(
     {
         vol.Optional("entity_id"): vol.Any(cv.entity_id, [cv.entity_id]),
         vol.Optional(SERVICE_SNAPSHOT_FILENAME): cv.string,
@@ -161,15 +160,15 @@ async def _async_handle_move_to_preset(hass: HomeAssistant, call: ServiceCall) -
 
 
 
-def _latest_event_payload(
+def _latest_motion_event_payload(
     coordinator: BlueIrisDataUpdateCoordinator,
     camera_id: str,
     *,
     filename: str | None = None,
 ) -> dict[str, Any]:
-    """Build a response payload for the latest event snapshot service."""
+    """Build a response payload for the latest motion event snapshot service."""
     data = coordinator.data
-    event = coordinator.get_last_event(camera_id)
+    event = coordinator.get_last_motion_event(camera_id)
     camera = data.cameras.get(camera_id) if data else None
 
     return {
@@ -187,10 +186,10 @@ def _latest_event_payload(
     }
 
 
-async def _async_handle_latest_event_snapshot(
+async def _async_handle_latest_motion_event_snapshot(
     hass: HomeAssistant, call: ServiceCall
 ) -> dict[str, Any]:
-    """Return latest event metadata and optionally save a current still image."""
+    """Return latest motion event metadata and optionally save a current still image."""
     entity_id = call.data.get("entity_id")
     if entity_id is None:
         entity_id = call.target.get("entity_id")
@@ -234,11 +233,11 @@ async def _async_handle_latest_event_snapshot(
     await hass.async_add_executor_job(path.write_bytes, image)
 
     _LOGGER.debug("Saved Blue Iris snapshot for %s to %s", entity_id, path)
-    coordinator.set_last_event_stored_path(camera_id, str(path))
+    coordinator.set_last_motion_event_stored_path(camera_id, str(path))
 
     local_url = f"/local/blueiris/{filename}"
 
-    payload = _latest_event_payload(coordinator, camera_id, filename=filename)
+    payload = _latest_motion_event_payload(coordinator, camera_id, filename=filename)
     payload["saved_filename"] = filename
     payload["saved_path"] = str(path)
     payload["local_snapshot_url"] = local_url
@@ -311,12 +310,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             schema=RELOAD_SCHEMA,
         )
 
-    if not hass.services.has_service(DOMAIN, SERVICE_LATEST_EVENT_SNAPSHOT):
+    if not hass.services.has_service(DOMAIN, SERVICE_LATEST_MOTION_EVENT_SNAPSHOT):
         hass.services.async_register(
             DOMAIN,
-            SERVICE_LATEST_EVENT_SNAPSHOT,
-            partial(_async_handle_latest_event_snapshot, hass),
-            schema=LATEST_EVENT_SNAPSHOT_SCHEMA,
+            SERVICE_LATEST_MOTION_EVENT_SNAPSHOT,
+            partial(_async_handle_latest_motion_event_snapshot, hass),
+            schema=LATEST_MOTION_EVENT_SNAPSHOT_SCHEMA,
             supports_response=SupportsResponse.OPTIONAL,
         )
 

--- a/custom_components/blueiris/__init__.py
+++ b/custom_components/blueiris/__init__.py
@@ -214,7 +214,7 @@ async def _async_handle_latest_motion_event_snapshot(
     if filename:
         filename = Path(filename).name
     else:
-        filename = f"{camera_id.lower()}_latest.jpg"
+        filename = f"{camera_id.lower()}_latest_motion.jpg"
 
     image = await coordinator.async_fetch_camera_snapshot(camera_id)
     if image is None:

--- a/custom_components/blueiris/camera.py
+++ b/custom_components/blueiris/camera.py
@@ -126,18 +126,18 @@ class BlueIrisCamera(CoordinatorEntity[BlueIrisData], Camera):
                 elif k in ALLOWED_COMPLEX_KEYS:
                     attrs[k] = v
 
-        event = self.coordinator.get_last_event(self.camera_id)
+        event = self.coordinator.get_last_motion_event(self.camera_id)
         if event is not None:
-            attrs["last_ai_event"] = event.state
-            attrs["last_ai_event_type"] = event.event_type
-            attrs["last_ai_event_time"] = event.last_detection
+            attrs["last_motion_event"] = event.state
+            attrs["last_motion_event_type"] = event.event_type
+            attrs["last_motion_event_time"] = event.last_detection
             attrs["last_snapshot_url"] = event.snapshot_url
             if event.memo is not None:
-                attrs["last_ai_event_memo"] = event.memo
+                attrs["last_motion_event_memo"] = event.memo
             if event.labels is not None:
-                attrs["last_ai_labels"] = event.labels
+                attrs["last_motion_labels"] = event.labels
             if event.matched_labels is not None:
-                attrs["last_ai_matched_labels"] = event.matched_labels
+                attrs["last_motion_matched_labels"] = event.matched_labels
             if event.stored_path is not None:
                 attrs["last_snapshot_path"] = event.stored_path
 

--- a/custom_components/blueiris/coordinator.py
+++ b/custom_components/blueiris/coordinator.py
@@ -155,8 +155,8 @@ class MqttEventState:
 
 
 @dataclass(slots=True)
-class CameraLastEvent:
-    """High-level latest AI event tracked per camera."""
+class CameraLastMotionEvent:
+    """High-level latest motion event tracked per camera."""
 
     camera_id: str
     event_type: str
@@ -182,7 +182,7 @@ class BlueIrisData:
     cameras: dict[str, CameraData]  # keyed by camera id
 
     mqtt: dict[str, MqttEventState]  # keyed by mqtt_key(...)
-    last_events: dict[str, CameraLastEvent]  # keyed by camera id
+    last_motion_events: dict[str, CameraLastMotionEvent]  # keyed by camera id
 
     base_url: str
     session_id: str | None
@@ -219,7 +219,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
         self.api = BlueIrisApi(hass, self._config)
 
         self._mqtt: dict[str, MqttEventState] = {}
-        self._last_events: dict[str, CameraLastEvent] = {}
+        self._last_motion_events: dict[str, CameraLastMotionEvent] = {}
 
         self._mqtt_unsub: Any | None = None
         self._mqtt_root = MQTT_ROOT_DEFAULT
@@ -316,18 +316,18 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
             return f"{base_url}/image/{camera_id}?session={session_id}"
         return f"{base_url}/image/{camera_id}"
 
-    def get_last_event(self, camera_id: str) -> CameraLastEvent | None:
+    def get_last_motion_event(self, camera_id: str) -> CameraLastMotionEvent | None:
         """Return the latest tracked AI event for a camera, if any."""
-        return self._last_events.get(camera_id)
+        return self._last_motion_events.get(camera_id)
 
-    def set_last_event_stored_path(self, camera_id: str, stored_path: str | None) -> None:
+    def set_last_motion_event_stored_path(self, camera_id: str, stored_path: str | None) -> None:
         """Persist the most recent saved snapshot path for a camera event."""
-        event = self._last_events.get(camera_id)
+        event = self._last_motion_events.get(camera_id)
         if event is None:
             return
         event.stored_path = stored_path
         if self.data is not None:
-            self.async_set_updated_data(replace(self.data, last_events=dict(self._last_events)))
+            self.async_set_updated_data(replace(self.data, last_motion_events=dict(self._last_motion_events)))
 
     def _record_last_motion_event(
         self,
@@ -341,7 +341,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
         animal_matched: list[str],
         ts: str,
     ) -> None:
-        """Store a high-level per-camera latest event snapshot."""
+        """Store a high-level per-camera latest motion event snapshot."""
         categories: list[str] = []
         if person_matched:
             categories.append("Person")
@@ -360,7 +360,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
             state = "Motion detected"
             event_type = "motion"
     
-        self._last_events[camera_id] = CameraLastEvent(
+        self._last_motion_events[camera_id] = CameraLastMotionEvent(
             camera_id=camera_id,
             event_type=event_type,
             state=state,
@@ -750,7 +750,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
             replace(
                 self.data,
                 mqtt=dict(self._mqtt),
-                last_events=dict(self._last_events),
+                last_motion_events=dict(self._last_motion_events),
             )
         )
 
@@ -864,7 +864,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
                 new_version=new_version,
                 cameras=cameras,
                 mqtt=self._mqtt,
-                last_events=dict(self._last_events),
+                last_motion_events=dict(self._last_motion_events),
                 base_url=self.api.base_url,
                 session_id=self.api.session_id,
             )

--- a/custom_components/blueiris/coordinator.py
+++ b/custom_components/blueiris/coordinator.py
@@ -317,7 +317,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
         return f"{base_url}/image/{camera_id}"
 
     def get_last_motion_event(self, camera_id: str) -> CameraLastMotionEvent | None:
-        """Return the latest tracked AI event for a camera, if any."""
+        """Return the latest tracked motion event for a camera, if any."""
         return self._last_motion_events.get(camera_id)
 
     def set_last_motion_event_stored_path(self, camera_id: str, stored_path: str | None) -> None:

--- a/custom_components/blueiris/helpers/const.py
+++ b/custom_components/blueiris/helpers/const.py
@@ -65,7 +65,7 @@ SERVICE_TRIGGER_CAMERA: Final[str] = "trigger_camera"
 SERVICE_MOVE_TO_PRESET: Final[str] = "move_to_preset"
 SERVICE_RELOAD: Final[str] = "reload"
 SERVICE_RELOAD_ENTRY_ID: Final[str] = "entry_id"
-SERVICE_LATEST_EVENT_SNAPSHOT: Final[str] = "latest_event_snapshot"
+SERVICE_LATEST_MOTION_EVENT_SNAPSHOT: Final[str] = "latest_motion_event_snapshot"
 SERVICE_SNAPSHOT_FILENAME: Final[str] = "filename"
 
 ATTR_ADMIN_PROFILE: Final[str] = "Profile"

--- a/custom_components/blueiris/sensor.py
+++ b/custom_components/blueiris/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import BlueIrisData, BlueIrisDataUpdateCoordinator, CameraLastEvent
+from .coordinator import BlueIrisData, BlueIrisDataUpdateCoordinator, CameraLastMotionEvent
 from .helpers.const import DOMAIN, SENSOR_MOTION_NAME
 from .helpers.device import camera_device_info, camera_model, server_device_info
 from .helpers.entity import base_name, is_allowed
@@ -28,9 +28,9 @@ CONNECTION_HEALTH_DESCRIPTION = BlueIrisSensorEntityDescription(
     icon="mdi:heart-pulse",
 )
 
-LAST_EVENT_DESCRIPTION = BlueIrisSensorEntityDescription(
-    key="last_event",
-    name="Last Event",
+LAST_MOTION_EVENT_DESCRIPTION = BlueIrisSensorEntityDescription(
+    key="last_motion_event",
+    name="Last Motion Event",
     icon="mdi:image-search",
 )
 
@@ -56,7 +56,7 @@ async def async_setup_entry(
                 continue
             if not _motion_sensor_enabled(coordinator, cam_id):
                 continue
-            entities.append(BlueIrisCameraLastEventSensor(coordinator, cam_id))
+            entities.append(BlueIrisCameraLastMotionEventSensor(coordinator, cam_id))
 
     async_add_entities(entities)
 
@@ -127,16 +127,16 @@ class BlueIrisConnectionHealthSensor(
         }
 
 
-class BlueIrisCameraLastEventSensor(CoordinatorEntity[BlueIrisData], SensorEntity):
-    """High-level per-camera latest AI event sensor."""
+class BlueIrisCameraLastMotionEventSensor(CoordinatorEntity[BlueIrisData], SensorEntity):
+    """High-level per-camera latest motion event sensor."""
 
-    entity_description = LAST_EVENT_DESCRIPTION
+    entity_description = LAST_MOTION_EVENT_DESCRIPTION
     _attr_has_entity_name = True
 
     def __init__(self, coordinator: BlueIrisDataUpdateCoordinator, camera_id: str) -> None:
         super().__init__(coordinator)
         self.camera_id = camera_id
-        self._attr_unique_id = f"{coordinator.entry.entry_id}_{camera_id}_last_event"
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_{camera_id}_last_motion_event"
 
     @property
     def _camera(self):
@@ -146,11 +146,11 @@ class BlueIrisCameraLastEventSensor(CoordinatorEntity[BlueIrisData], SensorEntit
         return data.cameras.get(self.camera_id)
 
     @property
-    def _event(self) -> CameraLastEvent | None:
+    def _event(self) -> CameraLastMotionEvent | None:
         data = self.coordinator.data
         if not data:
             return None
-        return data.last_events.get(self.camera_id)
+        return data.last_motion_events.get(self.camera_id)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/blueiris/services.yaml
+++ b/custom_components/blueiris/services.yaml
@@ -49,8 +49,8 @@ latest_motion_event_snapshot:
   fields:
     filename:
       name: Filename
-      description: Optional filename for the saved snapshot. If omitted, the integration will create one automatically (e.g. driveway_latest.jpg). Files are stored in /config/www/blueiris/.
+      description: Optional filename for the saved snapshot. If omitted, the integration will create one automatically (e.g. driveway_latest_motion.jpg). Files are stored in /config/www/blueiris/.
       required: false
-      example: driveway_latest.jpg
+      example: driveway_latest_motion.jpg
       selector:
         text:

--- a/custom_components/blueiris/services.yaml
+++ b/custom_components/blueiris/services.yaml
@@ -39,9 +39,9 @@ reload:
       selector:
         text:
 
-latest_event_snapshot:
-  name: Latest Event Snapshot
-  description: Returns metadata for the latest AI event for a Blue Iris camera and optionally saves a still image.
+latest_motion_event_snapshot:
+  name: Latest Motion Event Snapshot
+  description: Returns metadata for the latest motion event for a Blue Iris camera and optionally saves a still image.
   target:
     entity:
       integration: blueiris


### PR DESCRIPTION
Making the last event be motion specific. This way if I add a non-motion event sensor (like audio, connectivity, what-not) it can be handled separately