### PR TITLE
Added all of the exposed BI stream options

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ This integration builds upon the excellent work originally created by **elad-bar
 | Allowed Profiles | Multi-select | No | — | Controls which profiles are available in the Profile select |
 | Allowed Schedules | Multi-select | No | — | Controls which schedules are available in the Schedule select |
 
+### Stream Type Notes
+
+- **H264** uses Blue Iris `temp.m3u8` / HLS and is the default.
+- **H264 TS** uses Blue Iris `temp.ts` and may work better for some users, especially Blue Iris cycle/group cameras.
+- If live streaming is disabled, Home Assistant falls back to still-image refresh behavior, which may appear choppy.
+- **H264 Raw** and **MJPEG** are experimental and may not behave as live streams in all Home Assistant camera views.
+
 ### Removing camera devices
 
 To remove a Blue Iris camera from Home Assistant, first remove that camera from all relevant integration options, such as Allowed Cameras, Motion Sensors, Connectivity Sensors, Audio Sensors, DIO Sensors, and External Sensors. Save the options and reload the integration. Once the integration no longer provides entities for that camera, Home Assistant will allow the camera device to be deleted from the device page.

--- a/custom_components/blueiris/api/blue_iris_api.py
+++ b/custom_components/blueiris/api/blue_iris_api.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import logging
 from dataclasses import dataclass
-from datetime import UTC,datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import aiohttp
@@ -30,6 +30,7 @@ from ..helpers.const import (
     BI_ATTR_SYSTEM_NAME,
     BI_ATTR_IS_ENABLED,
     BI_ATTR_IS_ACTIVE,
+    DEFAULT_STREAM_TYPE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +51,7 @@ class BlueIrisConfig:
     password: str
 
     # options used by entity setup (kept here for convenience)
-    stream_type: str = "H264"
+    stream_type: str = DEFAULT_STREAM_TYPE
     support_stream: bool = False
     hold_profile_changes: bool = True
     allowed_camera: list[str] | None = None
@@ -300,7 +301,7 @@ class BlueIrisApi:
             try:
                 async with self.session.post(
                     self.url,
-                    json = payload,
+                    json=payload,
                     ssl=self._ssl_param(),
                 ) as response:
                     response.raise_for_status()

--- a/custom_components/blueiris/camera.py
+++ b/custom_components/blueiris/camera.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any, Final
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
@@ -19,9 +18,9 @@ from .helpers.const import (
     DOMAIN_STREAM,
     STREAM_VIDEO,
     DEFAULT_CONTENT_TYPE,
+    DEFAULT_STREAM_TYPE,
 )
 
-_LOGGER = logging.getLogger(__name__)
 ALLOWED_COMPLEX_KEYS: Final[set[str]] = {"group", "rects"}
 
 
@@ -59,7 +58,6 @@ class BlueIrisCamera(CoordinatorEntity[BlueIrisData], Camera):
             if coordinator.api.config.support_stream and DOMAIN_STREAM in coordinator.hass.data
             else CameraEntityFeature(0)
         )
-
 
     @property
     def _camera(self):
@@ -134,9 +132,12 @@ class BlueIrisCamera(CoordinatorEntity[BlueIrisData], Camera):
     async def stream_source(self) -> str | None:
         """Build the stream URL that Home Assistant should use for this camera."""
         cfg = self.coordinator.api.config
-        stream_config = STREAM_VIDEO.get(getattr(cfg, "stream_type", None), {})
-        stream_name = stream_config.get("stream_name") or "mjpg"
-        file_name = stream_config.get("file_name") or ""
+        stream_config = STREAM_VIDEO.get(
+            getattr(cfg, "stream_type", None),
+            STREAM_VIDEO[DEFAULT_STREAM_TYPE],
+        )
+        stream_name = stream_config.get("stream_name", "h264")
+        file_name = stream_config.get("file_name", "")
         data = self.coordinator.data
         if not data:
             return None
@@ -144,9 +145,8 @@ class BlueIrisCamera(CoordinatorEntity[BlueIrisData], Camera):
         session = data.session_id
         url = f"{base}/{stream_name}/{self.camera_id}/{file_name}"
         if session:
-            url = f"{url}?session={session}"
-        return url
-    
+            url = f"{url}?session={session}"         
+        return url    
 
     async def async_camera_image(
         self,

--- a/custom_components/blueiris/config_flow.py
+++ b/custom_components/blueiris/config_flow.py
@@ -44,9 +44,8 @@ from .helpers.const import (
     DEFAULT_VEHICLE_LABELS,
     DEFAULT_ANIMAL_LABELS,
     CONF_STREAM_TYPE,
-    DEFAULT_STREAM_TYPE,
-    STREAM_TYPE_H264,
-    STREAM_TYPE_MJPG,
+    DEFAULT_STREAM_TYPE,    
+    STREAM_VIDEO,
     CONF_SUPPORT_STREAM,
     CONF_HOLD_PROFILE_CHANGES,
     DEFAULT_HOLD_PROFILE_CHANGES,
@@ -155,11 +154,11 @@ def _build_settings_schema(
                 mode=selector.SelectSelectorMode.DROPDOWN,
             )
         ),
-        vol.Required(CONF_STREAM_TYPE, default=defaults[CONF_STREAM_TYPE]): selector.SelectSelector(
+        vol.Required(CONF_STREAM_TYPE, default=defaults.get(CONF_STREAM_TYPE, DEFAULT_STREAM_TYPE),): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=[
-                    selector.SelectOptionDict(value=STREAM_TYPE_H264, label=STREAM_TYPE_H264),
-                    selector.SelectOptionDict(value=STREAM_TYPE_MJPG, label=STREAM_TYPE_MJPG),
+                    selector.SelectOptionDict(value=value, label=value)
+                    for value in STREAM_VIDEO
                 ],
                 mode=selector.SelectSelectorMode.DROPDOWN,
             )

--- a/custom_components/blueiris/helpers/const.py
+++ b/custom_components/blueiris/helpers/const.py
@@ -42,12 +42,17 @@ CONF_SUPPORT_STREAM: Final[str] = "support_stream"
 # Keep as-is unless you also migrate existing stored options + translations.
 CONF_STREAM_TYPE: Final[str] = "stream-type"
 STREAM_TYPE_H264: Final[str] = "H264"
+STREAM_TYPE_H264_TS: Final[str] = "H264 TS"
+STREAM_TYPE_H264_RAW: Final[str] = "H264 Raw"
 STREAM_TYPE_MJPG: Final[str] = "MJPEG"
+
 DEFAULT_STREAM_TYPE: Final[str] = STREAM_TYPE_H264
 
 STREAM_VIDEO: Final[dict[str, dict[str, str]]] = {
     STREAM_TYPE_H264: {"file_name": "temp.m3u8", "stream_name": "h264"},
-    STREAM_TYPE_MJPG: {"stream_name": "mjpg"},
+    STREAM_TYPE_H264_TS: {"file_name": "temp.ts", "stream_name": "h264"},
+    STREAM_TYPE_H264_RAW: {"file_name": "temp.h264", "stream_name": "h264"},
+    STREAM_TYPE_MJPG: {"file_name": "video.mjpg", "stream_name": "mjpg"},
 }
 
 DOMAIN_STREAM: Final[str] = "stream"

--- a/custom_components/blueiris/manifest.json
+++ b/custom_components/blueiris/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/kramttocs/ha-blueiris/issues",
   "loggers": ["custom_components.blueiris"],
   "requirements": [],
-  "version": "2026.6.07"
+  "version": "2026.6.16"
 }


### PR DESCRIPTION
Added all of the exposed Blue Iris stream options to give users more options. Some work better with cycle groups whereas some don't work at all with cycle groups and some don't work at all with Home Assistant streaming. Add some notes in the ReadMe and will add more as users find things that work/don't work.