### PR TITLE
Refactor via_device logic to via_device_id for 2026.9.x

### DIFF
--- a/custom_components/blueiris/__init__.py
+++ b/custom_components/blueiris/__init__.py
@@ -124,17 +124,17 @@ def _normalize_system_name(value: object) -> str | None:
     return None
 
 
-async def _ensure_server_device(
+def _ensure_server_device(
     hass: HomeAssistant,
     entry: ConfigEntry,
     coordinator: BlueIrisDataUpdateCoordinator,
-) -> None:
-    """Ensure a "server" device exists for linking entities via_device."""
+) -> str:
+    """Ensure a server device exists for linking child camera devices."""
     device_reg = dr.async_get(hass)
 
     version = coordinator.data.server_version if coordinator.data else None
 
-    device_reg.async_get_or_create(
+    device = device_reg.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, f"{entry.entry_id}_server")},
         name=server_device_name(coordinator),
@@ -142,6 +142,8 @@ async def _ensure_server_device(
         model="Server",
         sw_version=version,
     )
+
+    return device.id
 
 
 async def _async_handle_reload(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -532,7 +534,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.config_entries.async_update_entry(entry, title=system_name)
 
     # Ensure the system device exists even if no switch entities are created.
-    await _ensure_server_device(hass, entry, coordinator)
+    coordinator.server_device_id = _ensure_server_device(
+        hass,
+        entry,
+        coordinator,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/blueiris/binary_sensor.py
+++ b/custom_components/blueiris/binary_sensor.py
@@ -210,6 +210,7 @@ class BlueIrisCameraBinarySensor(_BaseBIBinarySensor):
             self.camera_id,
             name=f"{base} {cam.name if cam else self.camera_id}",
             model=model,
+            server_device_id=self.coordinator.server_device_id,
         )
 
     @property

--- a/custom_components/blueiris/camera.py
+++ b/custom_components/blueiris/camera.py
@@ -96,6 +96,7 @@ class BlueIrisCamera(CoordinatorEntity[BlueIrisData], Camera):
             self.camera_id,
             name=self._camera_name,
             model=model,
+            server_device_id=self.coordinator.server_device_id,
         )
 
     @callback
@@ -145,7 +146,7 @@ class BlueIrisCamera(CoordinatorEntity[BlueIrisData], Camera):
         session = data.session_id
         url = f"{base}/{stream_name}/{self.camera_id}/{file_name}"
         if session:
-            url = f"{url}?session={session}"         
+            url = f"{url}?session={session}"
         return url    
 
     async def async_camera_image(

--- a/custom_components/blueiris/coordinator.py
+++ b/custom_components/blueiris/coordinator.py
@@ -213,6 +213,7 @@ class BlueIrisDataUpdateCoordinator(DataUpdateCoordinator[BlueIrisData]):
 
         self._config = self._config_from_entry(entry)
         self.api = BlueIrisApi(hass, self._config)
+        self.server_device_id: str | None = None
 
         self._mqtt: dict[str, MqttEventState] = {}
         self._last_motion_events: dict[str, CameraLastMotionEvent] = {}

--- a/custom_components/blueiris/helpers/device.py
+++ b/custom_components/blueiris/helpers/device.py
@@ -1,7 +1,7 @@
 """DeviceInfo helpers shared across platforms.
 
 These helpers centralize DeviceInfo construction to avoid drift across platforms.
-They are intentionally minimal and preserve existing identifiers/via_device patterns.
+They are intentionally minimal and preserve existing device identifiers.
 """
 
 from __future__ import annotations
@@ -43,20 +43,26 @@ def camera_device_info(
     *,
     name: str,
     model: str,
+    server_device_id: str | None,
     manufacturer: str = "Blue Iris",
 ) -> DeviceInfo:
     """Return DeviceInfo for a camera, linked via the server/system device."""
-    return DeviceInfo(
+    device_info = DeviceInfo(
         identifiers={(DOMAIN, f"{entry_id}_cam_{camera_id}")},
         name=name,
         manufacturer=manufacturer,
         model=model,
-        via_device=(DOMAIN, f"{entry_id}_server"),
     )
+
+    if server_device_id is not None:
+        device_info["via_device_id"] = server_device_id
+
+    return device_info
 
 
 def camera_model(camera_type: object) -> str:
     """Map a Blue Iris camera type code to a friendly device model string."""
     if isinstance(camera_type, int):
         return CAMERA_TYPE_MAPPING.get(camera_type, "Camera")
+
     return "Camera"

--- a/custom_components/blueiris/sensor.py
+++ b/custom_components/blueiris/sensor.py
@@ -160,6 +160,7 @@ class BlueIrisCameraLastMotionEventSensor(CoordinatorEntity[BlueIrisData], Senso
             self.camera_id,
             name=f"{base_name(self.coordinator)} {cam.name if cam else self.camera_id}",
             model=camera_model(cam.type if cam else None),
+            server_device_id=self.coordinator.server_device_id,
         )
 
     @property


### PR DESCRIPTION
Fix to address the via_device changes here: https://developers.home-assistant.io/blog/2026/08/24/device-registry-follow-up-changes/